### PR TITLE
Newer rusoto doesn't need auth

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,8 @@ serde = "1.0.11"
 serde_json = "1.0.2"
 serde_derive = "1.0.11"
 # Rusoto AWS API
-rusoto_core = {version="0.27.0"}
-rusoto_ec2 = {version="0.27.0"}
+rusoto_core = {version="0.34.0"}
+rusoto_ec2 = {version="0.34.0"}
 
 # regular expressions for when I'm ready to filter fields
 regex = "0.2"


### PR DESCRIPTION
We need a newer version due to dependencies. The upgrade to openssl
1.1.1 in ubuntu 18.10 requires this.